### PR TITLE
feat: user 권한 변경에 따른 로그아웃 기능 추가

### DIFF
--- a/src/main/kotlin/nhncommerce/project/security/SecurityConfig.kt
+++ b/src/main/kotlin/nhncommerce/project/security/SecurityConfig.kt
@@ -6,10 +6,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.session.SessionRegistry
+import org.springframework.security.core.session.SessionRegistryImpl
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+
 
 @Configuration
 @EnableWebSecurity
@@ -21,6 +23,11 @@ class SecurityConfig(
     @Bean
     fun passwordEncoder(): PasswordEncoder {
         return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun sessionRegistry(): SessionRegistry {
+        return SessionRegistryImpl()
     }
 
     @Bean
@@ -54,6 +61,7 @@ class SecurityConfig(
             .and()
             .sessionManagement()
             .maximumSessions(1)
+            .expiredUrl("/api/users/sessionExpired")
 //            .maxSessionsPreventsLogin(true) // session 중복 로그인 처리
 //            .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) // default session 생성 방식
             .and()

--- a/src/main/kotlin/nhncommerce/project/security/service/Oauth2LoginUserService.kt
+++ b/src/main/kotlin/nhncommerce/project/security/service/Oauth2LoginUserService.kt
@@ -18,8 +18,8 @@ class Oauth2LoginUserService(
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User: OAuth2User = super.loadUser(userRequest)
         val provider = userRequest.clientRegistration.registrationId // google
-        val providerId = oAuth2User.attributes["sub"] as String
-        val username = oAuth2User.attributes["name"] as  String
+        val oauthId = oAuth2User.attributes["sub"] as String
+        val username = oAuth2User.attributes["name"] as String
         val email = oAuth2User.attributes["email"] as String
         val role = ROLE.ROLE_USER
 
@@ -30,10 +30,9 @@ class Oauth2LoginUserService(
                     name = username,
                     email = email,
                     role = role,
-                    oauthId = providerId,
+                    oauthId = oauthId,
                     provider = provider,
                     gender = Gender.MALE,
-                    phone = "",
                     status = Status.ACTIVE
                 )
             )

--- a/src/main/kotlin/nhncommerce/project/user/UserService.kt
+++ b/src/main/kotlin/nhncommerce/project/user/UserService.kt
@@ -2,9 +2,6 @@ package nhncommerce.project.user
 
 
 import com.querydsl.core.BooleanBuilder
-import nhncommerce.project.baseentity.ROLE
-import nhncommerce.project.deliver.domain.Deliver
-import nhncommerce.project.deliver.domain.DeliverListDTO
 import nhncommerce.project.exception.RedirectException
 import nhncommerce.project.page.PageRequestDTO
 import nhncommerce.project.page.PageResultDTO

--- a/src/main/kotlin/nhncommerce/project/user/domain/AdminProfileDTO.kt
+++ b/src/main/kotlin/nhncommerce/project/user/domain/AdminProfileDTO.kt
@@ -6,12 +6,13 @@ import javax.validation.constraints.Size
 
 data class AdminProfileDTO (
 
-    @field:Size(max = 30, message = "이름을 30자 이내로 입력하세요")
+    @field:Size(max = 20, message = "이름을 20자 이내로 입력해주세요")
     @field:NotBlank(message = "이름을 입력해주세요.")
     val name: String = "",
 
     @field:NotBlank(message = "전회번호를 입력해주세요.")
-    val phone: String = "",
+    @field:Size(max = 13, message = "전화번호를 13자 이내로 입력해주세요")
+    val phone: String ?= null,
 
     @field:NotBlank(message = "권한을 선해주세요.")
     val role: String,

--- a/src/main/kotlin/nhncommerce/project/user/domain/PasswordDTO.kt
+++ b/src/main/kotlin/nhncommerce/project/user/domain/PasswordDTO.kt
@@ -1,6 +1,7 @@
 package nhncommerce.project.user.domain
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 
 data class PasswordDTO(
@@ -9,8 +10,10 @@ data class PasswordDTO(
     val password: String = "",
 
     @field:NotBlank(message = "새로운 비밀번호를 입력해주세요.")
+    @field:Size(min = 6, max = 20, message = "비밀번호를 6자 이상 20자 이내로 입력해주세요")
     val newPassword: String = "",
 
     @field:NotBlank(message = "새로운 비밀번호를 한번 더 입력해주세요.")
+    @field:Size(min = 6, max = 20, message = "비밀번호를 6자 이상 20자 이내로 입력해주세요")
     val newPasswordVerify: String = "",
 ) {}

--- a/src/main/kotlin/nhncommerce/project/user/domain/ProfileDTO.kt
+++ b/src/main/kotlin/nhncommerce/project/user/domain/ProfileDTO.kt
@@ -1,13 +1,16 @@
 package nhncommerce.project.user.domain
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class ProfileDTO (
 
+    @field:Size(max = 20, message = "이름을 20자 이내로 입력해주세요")
     @field:NotBlank(message = "이름을 입력해주세요.")
     val name: String = "",
 
     @field:NotBlank(message = "전회번호를 입력해주세요.")
-    val phone: String = "",
+    @field:Size(max = 13, message = "전화번호를 13자 이내로 입력해주세요")
+    val phone: String ?= null,
 
 ) {}

--- a/src/main/kotlin/nhncommerce/project/user/domain/User.kt
+++ b/src/main/kotlin/nhncommerce/project/user/domain/User.kt
@@ -32,8 +32,8 @@ class User (
     @Column() // oauth 로그인은 비밀번호가 없음 null 허용
     var password: String? = null,
 
-    @Column(nullable = false, length = 13)
-    var phone: String,
+    @Column(length = 13)
+    var phone: String? = null,
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -71,9 +71,9 @@ class User (
             email = email,
             gender = gender.name,
             name = name,
-            password = password ?: "",
+            password = password,
             phone = phone,
-            provider = provider ?: "",
+            provider = provider,
         )
     }
 

--- a/src/main/kotlin/nhncommerce/project/user/domain/UserDTO.kt
+++ b/src/main/kotlin/nhncommerce/project/user/domain/UserDTO.kt
@@ -14,22 +14,23 @@ data class UserDTO (
     @field:NotBlank(message = "성별을 선택해주세요.")
     val gender: String = "",
 
-    @field:Size(max = 30, message = "이름을 30자 이내로 입력하세요")
+    @field:Size(max = 20, message = "이름을 20자 이내로 입력해주세요")
     @field:NotBlank(message = "이름을 입력해주세요.")
     val name: String = "",
 
     @field:NotBlank(message = "비밀번호를 입력해주세요.")
-    @field:Size(max = 30, message = "비밀번호를 30자 이내로 입력하세요")
-    val password: String = "",
+    @field:Size(min = 6, max = 20, message = "비밀번호를 6자 이상 20자 이내로 입력해주세요")
+    val password: String? = null,
 
     @field:NotBlank(message = "비밀번호를 한번 더 입력해주세요.")
-    @field:Size(max = 30, message = "비밀번호를 30자 이내로 입력하세요")
+    @field:Size(min = 6, max = 20, message = "비밀번호를 6자 이상 20자 이내로 입력해주세요")
     val passwordVerify: String = "",
 
     @field:NotBlank(message = "전회번호를 입력해주세요.")
-    val phone: String = "",
+    @field:Size(max = 13, message = "전화번호를 13자 이내로 입력해주세요")
+    val phone: String? = null,
 
-    val provider: String = "",
+    val provider: String? = null,
 ) {
     fun toEntity(): User {
         val genderStatus: Gender = if (gender == "MALE") {


### PR DESCRIPTION
유저의 권한이 변경되었다 해도 세션에 반영이 안되는 에러 발생.

따라서, 권한이 변경된 유저를 강제 로그아웃(세션 만료시킴) 이후, 재 로그인을 통하여 세션을 재발급 받도록 함.

db 에 null 값이 아닌 빈 문자열이 들어가는 에러를 확인하여 코드 수정함.